### PR TITLE
Hacktoberfest fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,12 @@ lint_and_unit: &lint_and_unit
   - danger
   - lint-yaml
   - lint-markdown
-
 version: 2.1
 orbs:
   kitchen: sous-chefs/kitchen@2
-
 workflows:
   kitchen:
     jobs:
-      # Lint and Unit Test
       - kitchen/yamllint:
           name: lint-yaml
       - kitchen/mdlint:
@@ -22,9 +19,27 @@ workflows:
           context: Danger
       - kitchen/delivery:
           name: delivery
-
       - kitchen/dokken-single:
-          name: default
-          suite: default
-          requires:
-            *lint_and_unit
+          name: default-debian-8
+          suite: default-debian-8
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-debian-9
+          suite: default-debian-9
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-centos-7
+          suite: default-centos-7
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-fedora-latest
+          suite: default-fedora-latest
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-ubuntu-1604
+          suite: default-ubuntu-1604
+          requires: *lint_and_unit
+      - kitchen/dokken-single:
+          name: default-ubuntu-1804
+          suite: default-ubuntu-1804
+          requires: *lint_and_unit

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,0 @@
----
-
-AllCops:
-  Exclude:
-    - 'Dangerfile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is used to list changes made in each version of the git_checkout cookbook.
 
+## 1.0.1
+
+- Added `.gitattributes` to ensure `lf` line endings
+- Updated circleci builds to be parallel
+- Updated cookbook with latest `cookstyle` fixes
+- Changed `Dangerfile` to use `failure` instead of `fail`
+- Removed `.rubocop.yml` as no longer required
+
 ## 1.0.0
 
 - Added extension management

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+failure 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a CHANGELOG entry.'
+  failure 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,10 @@ maintainer        'Sous Chefs'
 maintainer_email  'help@sous-chefs.org'
 license           'Apache-2.0'
 description       'Installs and manages Visual Studio Code Extensions'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.0.0'
 source_url        'https://github.com/sous-chefs/vscode'
 issues_url        'https://github.com/sous-chefs/vscode/issues'
 chef_version      '>= 13.0'
+version           '1.0.1'
 
 %w(ubuntu redhat centos fedora).each do |os|
   supports os

--- a/test/fixtures/cookbooks/test/recipes/install.rb
+++ b/test/fixtures/cookbooks/test/recipes/install.rb
@@ -6,11 +6,11 @@ end
 
 # We need a couple prereqs for testing as servers do not have a GUI,
 # this is not expected in live, as no one would install vscode without a GUI?
-case node[:platform]
+case node['platform']
 when 'fedora'
   package_name = 'libX11-xcb'
 when 'ubuntu', 'debian'
-  package_name = ['libx11-xcb1', 'libxss1', 'libasound2', 'libxkbfile1']
+  package_name = %w(libx11-xcb1 libxss1 libasound2 libxkbfile1)
 end
 
 package 'testing-prereqs' do


### PR DESCRIPTION
# Description

Various fixes:

- Added `.gitattributes` to ensure `lf` line endings
- Updated circleci builds to be parallel
- Updated cookbook with latest `cookstyle` fixes
- Changed `Dangerfile` to use `failure` instead of `fail`
- Removed `.rubocop.yml` as no longer required

Signed-off-by: Jason Field <jason@avon-lea.co.uk>

## Issues Resolved

#16,  #17, #18, #19, #20 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
